### PR TITLE
Update gke.md

### DIFF
--- a/docs/gke.md
+++ b/docs/gke.md
@@ -90,7 +90,7 @@ not forgetting to set the correspondent context for further steps:
 4. Deploy the operator with the following command:
 
     ``` {.bash data-prompt="$" }
-    $ kubectl apply -f deploy/operator.yaml
+    $ kubectl apply -f deploy/operator.yaml --server-side
     ```
 
 5. After the operator is started Percona Distribution for PostgreSQL


### PR DESCRIPTION
without server-side flag the bundle installation will fail with 
```
Error from server (Invalid): error when creating "deploy/bundle.yaml": CustomResourceDefinition.apiextensions.k8s.io "perconapgclusters.pg.percona.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
Error from server (Invalid): error when creating "deploy/bundle.yaml": CustomResourceDefinition.apiextensions.k8s.io "postgresclusters.postgres-operator.crunchydata.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```