### PR TITLE
K8SPG-413 add feature compatibility matrix

### DIFF
--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -8,20 +8,29 @@ The Operator {{ release }} was developed and tested with PostgreSQL versions 12.
 
 ## Supported platforms
 
-The following platforms were tested and are officially supported by the Operator:
+The following platforms were tested and are officially supported by the Operator
+{{ release }}:
 
-| Operator | PostgreSQL | [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)         | [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
-|:--------|:--------|:------------|:------------|:------------|:----------------------------------|
-| 2.2.0   | 12 - 15 | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
-| 2.1.0   | 12 - 15 | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
-| 2.0.0   | 12 - 14 | 1.22 - 1.25 |             |             |                                   |
-| 1.4.0   | 12 - 14 | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
-| 1.3.0   | 12 - 14 | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
-| 1.2.0   | 12 - 14 | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
-| 1.1.0   | 12 - 14 | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
-| 1.0.0   | 12 - 13 | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
+* [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
+* [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com)
+* [Minikube](https://github.com/kubernetes/minikube)
 
 Other Kubernetes platforms may also work but have not been tested.
+
+The version compatibility matrix across the different Operator releases is
+shown below:
+
+| Operator | PostgreSQL | pgBackRest | pgBouncer | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
+|:--------|:--------|:-----|:-------|:------------|:------------|:------------|:----------------------------------|
+| 2.2.0   | 12 - 15 | 2.43 | 1.18.0 | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
+| 2.1.0   | 12 - 15 | 2.43 | 1.18.0 | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
+| 2.0.0   | 12 - 14 | 2.41 | 1.17.0 | 1.22 - 1.25 |             |             |                                   |
+| 1.4.0   | 12 - 14 | 2.43 | 1.18.0 | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
+| 1.3.0   | 12 - 14 | 2.38 | 1.17.0 | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
+| 1.2.0   | 12 - 14 | 2.37 | 1.16.1 | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
+| 1.1.0   | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12; 1.16.1 | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
+| 1.0.0   | 12 - 13 | 2.33 | 1.13.0 | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
+
 
 ## Installation guidelines
 

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -17,10 +17,9 @@ The following platforms were tested and are officially supported by the Operator
 
 Other Kubernetes platforms may also work but have not been tested.
 
-The version compatibility matrix across the different Operator releases is
-shown below:
+The version compatibility matrix for different Operator releases is shown below:
 
-| Operator | PostgreSQL | pgBackRest | pgBouncer | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
+| Operator | [PostgreSQL](https://www.postgresql.org/) | [pgBackRest](https://pgbackrest.org/) | [pgBouncer](http://pgbouncer.github.io/) | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
 |:--------|:--------|:-----|:-------|:------------|:------------|:------------|:----------------------------------|
 | 2.2.0   | 12 - 15 | 2.43 | 1.18.0 | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
 | 2.1.0   | 12 - 15 | 2.43 | 1.18.0 | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
@@ -28,7 +27,7 @@ shown below:
 | 1.4.0   | 12 - 14 | 2.43 | 1.18.0 | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
 | 1.3.0   | 12 - 14 | 2.38 | 1.17.0 | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
 | 1.2.0   | 12 - 14 | 2.37 | 1.16.1 | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
-| 1.1.0   | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12; 1.16.1 | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
+| 1.1.0   | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12; 1.16.1 for other versions | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
 | 1.0.0   | 12 - 13 | 2.33 | 1.13.0 | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
 
 

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -4,7 +4,7 @@ The Operator is validated for deployment on Kubernetes, GKE and EKS clusters.
 The Operator is cloud native and storage agnostic, working with a wide variety
 of storage classes, hostPath, and NFS.
 
-The Operator was developed and tested with PostgreSQL versions 12.14, 13.10, 14.7, and 15.2. Other options may also work but have not been tested. The Operator provides connection pooling based on [`pgBouncer`](https://www.pgbouncer.org/) 1.18.0 and high-availability implementation based on [`Patroni`](https://patroni.readthedocs.io/en/latest/) 3.0.1.
+The Operator {{ release }} was developed and tested with PostgreSQL versions 12.14, 13.10, 14.7, and 15.2. Other options may also work but have not been tested. The Operator provides connection pooling based on [`pgBouncer`](https://www.pgbouncer.org/) 1.18.0 and high-availability implementation based on [`Patroni`](https://patroni.readthedocs.io/en/latest/) 3.0.1.
 
 ## Supported platforms
 

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -8,14 +8,18 @@ The Operator was developed and tested with PostgreSQL versions 12.14, 13.10, 14.
 
 ## Supported platforms
 
-The following platforms were tested and are officially supported by the Operator
-{{ release }}:
+The following platforms were tested and are officially supported by the Operator:
 
-* [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) 1.23 - 1.26
-
-* [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com) 1.23 - 1.27
-
-* [Minikube](https://github.com/kubernetes/minikube) 1.30.1 (based on Kubernetes 1.27)
+| Operator | PostgreSQL | [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)         | [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
+|:--------|:--------|:------------|:------------|:------------|:----------------------------------|
+| 2.2.0   | 12 - 15 | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
+| 2.1.0   | 12 - 15 | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
+| 2.0.0   | 12 - 14 | 1.22 - 1.25 |             |             |                                   |
+| 1.4.0   | 12 - 14 | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
+| 1.3.0   | 12 - 14 | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
+| 1.2.0   | 12 - 14 | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
+| 1.1.0   | 12 - 14 | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
+| 1.0.0   | 12 - 13 | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
 
 Other Kubernetes platforms may also work but have not been tested.
 
@@ -29,3 +33,5 @@ Choose how you wish to install Percona Operator for PostgreSQL:
 * [on Google Kubernetes Engine (GKE)](gke.md)
 * [on Amazon Elastic Kubernetes Service (AWS EKS)](eks.md)
 * [in a Kubernetes-based environment](kubernetes.md)
+
+

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -4,32 +4,20 @@ The Operator is validated for deployment on Kubernetes, GKE and EKS clusters.
 The Operator is cloud native and storage agnostic, working with a wide variety
 of storage classes, hostPath, and NFS.
 
-The Operator {{ release }} was developed and tested with PostgreSQL versions 12.14, 13.10, 14.7, and 15.2. Other options may also work but have not been tested. The Operator provides connection pooling based on [`pgBouncer`](https://www.pgbouncer.org/) 1.18.0 and high-availability implementation based on [`Patroni`](https://patroni.readthedocs.io/en/latest/) 3.0.1.
+The Operator was developed and tested with PostgreSQL versions 12.14, 13.10, 14.7, and 15.2. Other options may also work but have not been tested. The Operator provides connection pooling based on [`pgBouncer`](https://www.pgbouncer.org/) 1.18.0 and high-availability implementation based on [`Patroni`](https://patroni.readthedocs.io/en/latest/) 3.0.1.
 
 ## Supported platforms
 
 The following platforms were tested and are officially supported by the Operator
 {{ release }}:
 
-* [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
-* [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com)
-* [Minikube](https://github.com/kubernetes/minikube)
+* [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) 1.23 - 1.26
+
+* [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com) 1.23 - 1.27
+
+* [Minikube](https://github.com/kubernetes/minikube) 1.30.1 (based on Kubernetes 1.27)
 
 Other Kubernetes platforms may also work but have not been tested.
-
-The version compatibility matrix for different Operator releases is shown below:
-
-| Operator | [PostgreSQL](https://www.postgresql.org/) | [pgBackRest](https://pgbackrest.org/) | [pgBouncer](http://pgbouncer.github.io/) | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
-|:--------|:--------|:-----|:-------|:------------|:------------|:------------|:----------------------------------|
-| 2.2.0   | 12 - 15 | 2.43 | 1.18.0 | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
-| 2.1.0   | 12 - 15 | 2.43 | 1.18.0 | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
-| 2.0.0   | 12 - 14 | 2.41 | 1.17.0 | 1.22 - 1.25 |             |             |                                   |
-| 1.4.0   | 12 - 14 | 2.43 | 1.18.0 | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
-| 1.3.0   | 12 - 14 | 2.38 | 1.17.0 | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
-| 1.2.0   | 12 - 14 | 2.37 | 1.16.1 | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
-| 1.1.0   | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12; 1.16.1 for other versions | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
-| 1.0.0   | 12 - 13 | 2.33 | 1.13.0 | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
-
 
 ## Installation guidelines
 
@@ -41,5 +29,3 @@ Choose how you wish to install Percona Operator for PostgreSQL:
 * [on Google Kubernetes Engine (GKE)](gke.md)
 * [on Amazon Elastic Kubernetes Service (AWS EKS)](eks.md)
 * [in a Kubernetes-based environment](kubernetes.md)
-
-

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -17,11 +17,11 @@ Cluster components:
 
 Platforms:
 
-| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift) <br> (coming soon for 2.x)  | [Minikube](https://github.com/kubernetes/minikube)                          |
+| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift) | [Minikube](https://github.com/kubernetes/minikube)                          |
 |:--------|:------------|:------------|:------------|:----------------------------------|
-| [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 1.23 - 1.26 | 1.23 - 1.27 | - | 1.30.1 |
-| [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 1.23 - 1.25 | 1.23 - 1.25 | - | - |
-| [2.0.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.0.0.md) | 1.22 - 1.25 |      -      | - | - |
+| [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 1.23 - 1.26 | 1.23 - 1.27 | coming soon | 1.30.1 |
+| [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 1.23 - 1.25 | 1.23 - 1.25 | coming soon | - |
+| [2.0.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.0.0.md) | 1.22 - 1.25 |      -      | coming soon | - |
 | [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 |
 | [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  | - |
 | [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  | - |

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -12,12 +12,12 @@ Cluster components:
 | [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 12 - 14 | 2.43 | 1.18.0 |
 | [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 12 - 14 | 2.38 | 1.17.0 |
 | [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 12 - 14 | 2.37 | 1.16.1 |
-| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12, 1.16.1 for other versions |
+| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12, <br> 1.16.1 for other versions |
 | [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 12 - 13 | 2.33 | 1.13.0 |
 
 Platforms:
 
-| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift) (coming soon for 2.x)  | [Minikube](https://github.com/kubernetes/minikube)                          |
+| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift) <br> (coming soon for 2.x)  | [Minikube](https://github.com/kubernetes/minikube)                          |
 |:--------|:------------|:------------|:------------|:----------------------------------|
 | [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 1.23 - 1.26 | 1.23 - 1.27 | - | 1.30.1 |
 | [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 1.23 - 1.25 | 1.23 - 1.25 | - | - |

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -12,19 +12,19 @@ Cluster components:
 | [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 12 - 14 | 2.43 | 1.18.0 |
 | [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 12 - 14 | 2.38 | 1.17.0 |
 | [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 12 - 14 | 2.37 | 1.16.1 |
-| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12; 1.16.1 for other versions |
+| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12, 1.16.1 for other versions |
 | [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 12 - 13 | 2.33 | 1.13.0 |
 
 Platforms:
 
-| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
+| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift) (coming soon for 2.x)  | [Minikube](https://github.com/kubernetes/minikube)                          |
 |:--------|:------------|:------------|:------------|:----------------------------------|
-| [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
-| [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
-| [2.0.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.0.0.md) | 1.22 - 1.25 |             |             |                                   |
-| [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
-| [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
-| [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
-| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
-| [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
+| [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 1.23 - 1.26 | 1.23 - 1.27 | - | 1.30.1 |
+| [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 1.23 - 1.25 | 1.23 - 1.25 | - | - |
+| [2.0.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.0.0.md) | 1.22 - 1.25 |      -      | - | - |
+| [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 |
+| [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  | - |
+| [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  | - |
+| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   | - |
+| [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 1.17 - 1.21 | 1.21        | 4.6 - 4.8 | - |
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -26,5 +26,5 @@ Platforms:
 | [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  | - |
 | [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  | - |
 | [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   | - |
-| [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 1.17 - 1.21 | 1.21        | 4.6 - 4.8 | - |
+| [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   | - |
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,30 @@
+# Versions compatibility
+
+Versions of the cluster components and platforms tested with different Operator releases are shown below. Other version combinations may also work but have not been tested.
+
+Cluster components:
+
+| Operator | [PostgreSQL](https://www.postgresql.org/) | [pgBackRest](https://pgbackrest.org/) | [pgBouncer](http://pgbouncer.github.io/) |
+|:--------|:--------|:-----|:-------|
+| [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 12 - 15 | 2.43 | 1.18.0 |
+| [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 12 - 15 | 2.43 | 1.18.0 |
+| [2.0.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.0.0.md) | 12 - 14 | 2.41 | 1.17.0 |
+| [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 12 - 14 | 2.43 | 1.18.0 |
+| [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 12 - 14 | 2.38 | 1.17.0 |
+| [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 12 - 14 | 2.37 | 1.16.1 |
+| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 12 - 14 | 2.34 | 1.16.0 for PostgreSQL 12; 1.16.1 for other versions |
+| [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 12 - 13 | 2.33 | 1.13.0 |
+
+Platforms:
+
+| Operator | [GKE](https://cloud.google.com/kubernetes-engine)         | [EKS](https://aws.amazon.com)         | [Openshift](https://www.redhat.com/en/technologies/cloud-computing/openshift)   | [Minikube](https://github.com/kubernetes/minikube)                          |
+|:--------|:------------|:------------|:------------|:----------------------------------|
+| [2.2.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.2.0.md) | 1.23 - 1.26 | 1.23 - 1.27 |             | 1.30.1 (based on Kubernetes 1.27) |
+| [2.1.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.1.0.md) | 1.23 - 1.25 | 1.23 - 1.25 |             |                                   |
+| [2.0.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.0.0.md) | 1.22 - 1.25 |             |             |                                   |
+| [1.4.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.4.0.html) | 1.22 - 1.25 | 1.22 - 1.25 | 4.10 - 4.12 | 1.28 (based on Kubernetes 1.25)   |
+| [1.3.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.3.0.html) | 1.21 - 1.24 | 1.20 - 1.22 | 4.7 - 4.10  |                                   |
+| [1.2.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.2.0.html) | 1.19 - 1.22 | 1.19 - 1.21 | 4.7 - 4.10  |                                   |
+| [1.1.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.1.0.html) | 1.19 - 1.22 | 1.18 - 1.21 | 4.7 - 4.9   |                                   |
+| [1.0.0](https://docs.percona.com/percona-operator-for-postgresql/1.0/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN1.0.0.html) | 1.17 - 1.21 | 1.21        | 4.6 - 4.8   |                                   |
+

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -173,6 +173,7 @@ nav:
     - Reference:
           - "Custom Resource options": operator.md
           - "Percona certified images": images.md
+          - "Versions compatibility": versions.md
           - "Copyright and licensing information": copyright.md
           - "Trademark policy": trademark-policy.md
     - Release Notes:


### PR DESCRIPTION
Versions were taken from images.html and SystemRequrements.html pages of the previous released versions, and checks done with "docker run -it percona/percona-postgresql-operator:X.X.0-ppgXX-pgbouncer pgbouncer --version" and "docker run -it percona/percona-postgresql-operator:X.X.0-ppgXX-pgbackrest pgbackrest version" commands