### PR TITLE
Adds v2.5.1 in the release notes index

### DIFF
--- a/docs/ReleaseNotes/index.md
+++ b/docs/ReleaseNotes/index.md
@@ -1,5 +1,7 @@
 # Percona Operator for PostgreSQL Release Notes
 
+* [*Percona Operator for PostgreSQL* 2.5.1 (2025-03-03)](Kubernetes-Operator-for-PostgreSQL-RN2.5.1.md)
+
 * [*Percona Operator for PostgreSQL* 2.5.0 (2024-10-08)](Kubernetes-Operator-for-PostgreSQL-RN2.5.0.md)
 
 * [*Percona Operator for PostgreSQL* 2.4.1 (2024-08-06)](Kubernetes-Operator-for-PostgreSQL-RN2.4.1.md)


### PR DESCRIPTION
The link to v2.5.1 release notes is currently missing from the [index](https://docs.percona.com/percona-operator-for-postgresql/2.0/ReleaseNotes/index.html).

Thanks,