### PR TITLE
Added PG17.4 image to 2.6.0 release

### DIFF
--- a/docs/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md
+++ b/docs/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md
@@ -26,6 +26,8 @@ PostgreSQL 17 is now supported by the Operator in addition to versions 13 - 16. 
 
 PostgreSQL 17 is currently not recommended for production environments due to the [known limitation](#known-limitations).
 
+_Update from March 31, 2025_: PostgreSQL 17.4 image and database cluster components based on PostgreSQL 17.4 were added.
+
 ### `pgvector` is added to the PostgreSQL image
 
 To support you with your AI journey, we've added the `pgvector` extension to the PostgreSQL images shipped with our Operator. Now, you can easily use Percona Distribution for PostgreSQL as a vector database by simply enabling it in your [Custom Resource options](../operator.md#extensionsbuiltinpgvector). No more [custom extension installations :octicons-link-external-16:](https://www.percona.com/blog/create-an-ai-expert-with-open-source-tools-and-pgvector/) needed.
@@ -73,22 +75,25 @@ To support you with your AI journey, we've added the `pgvector` extension to the
 
 ## Known limitations
 
-PostgreSQL 17.2 image and images for other database cluster components based on PostgreSQL 17 contain the known [CVE-2025-1094 :octicons-link-external-16:](https://www.postgresql.org/support/security/CVE-2025-1094/) - a vulnerability in the libpq PostgreSQL client library, which makes images used by the Operator vulnerable to SQL injection within the PostgreSQL interactive terminal due to the lack of neutralizing quoting. Images for PostgreSQL 17 will be available soon, while images for other PosgreSQL versions have already been fixed.
+* PostgreSQL 17.2 image and images for other database cluster components based on PostgreSQL 17 contain the known [CVE-2025-1094 :octicons-link-external-16:](https://www.postgresql.org/support/security/CVE-2025-1094/) - a vulnerability in the libpq PostgreSQL client library, which makes images used by the Operator vulnerable to SQL injection within the PostgreSQL interactive terminal due to the lack of neutralizing quoting. Images for PostgreSQL 17 will be available soon, while images for other PosgreSQL versions have already been fixed.
+
+* PostgreSQL 17.4 image includes the fix for [CVE-2025-1094 :octicons-link-external-16:](https://www.postgresql.org/support/security/CVE-2025-1094/), which closed a vulnerability in the `libpq` PostgreSQL client library but introduced a regression related to string handling for non-null terminated strings. The error would be visible based on how a PostgreSQL client implemented this behavior. 
 
 ## Supported platforms
 
 The Operator {{ release }} is developed, tested and based on:
 
-* PostgreSQL 13.18, 14.15, 15.10, 16.6, and 17.2 as the database. Other versions may also work but have not been tested. 
+* PostgreSQL 13.18, 14.15, 15.10, 16.8, 17.2 and 17.4 as the database. Other versions may also work but have not been tested. 
 * pgBouncer for connection pooling:
 
     * version 1.23.1 - for PostgreSQL 17.2  
-    * version 1.24.0 - for PostgreSQL 13.18, 14.15, 15.10, 16.6 
+    * version 1.24.0 - for PostgreSQL 13.20, 14.17, 15.12, 16.8, 17.4
 
 * Patroni for high-availability:
 
+    * version 4.0.5 - for PostgreSQL 17.4
     * version 4.0.3 - for PostgreSQL 17.2  
-    * version 4.0.4 - for PostgreSQL 13.18, 14.15, 15.10, 16.6 
+    * version 4.0.4 - for PostgreSQL 13.20, 14.17, 15.12, 16.8 
 
 
 Percona Operators are designed for compatibility with all [CNCF-certified :octicons-link-external-16:](https://www.cncf.io/training/certification/software-conformance/) Kubernetes distributions. 

--- a/docs/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md
+++ b/docs/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md
@@ -26,7 +26,7 @@ PostgreSQL 17 is now supported by the Operator in addition to versions 13 - 16. 
 
 PostgreSQL 17 is currently not recommended for production environments due to the [known limitation](#known-limitations).
 
-_Update from March 31, 2025_: PostgreSQL 17.4 image and database cluster components based on PostgreSQL 17.4 were added.
+_Update from April 1, 2025_: We have added PostgreSQL 17.4 image and database cluster components based on this image. It is now production ready and we recommend updating the database cluster from PostgreSQL 17.2 to 17.4. Check the [upgrade instructions](../update.md#minor-version-upgrade) for steps
 
 ### `pgvector` is added to the PostgreSQL image
 

--- a/docs/assets/fragments/sw-versions.txt
+++ b/docs/assets/fragments/sw-versions.txt
@@ -1,10 +1,12 @@
-* PostgreSQL 13.18, 14.15, 15.10, 16.6, and 17.2 as the database. Other versions may also work but have not been tested. 
+ PostgreSQL 13.18, 14.15, 15.10, 16.8, 17.2 and 17.4 as the database. Other versions may also work but have not been tested. 
 * pgBouncer for connection pooling:
 
     * version 1.23.1 - for PostgreSQL 17.2  
-    * version 1.24.0 - for PostgreSQL 13.18, 14.15, 15.10, 16.6 
+    * version 1.24.0 - for PostgreSQL 13.20, 14.17, 15.12, 16.8, 17.4
 
 * Patroni for high-availability:
 
+    * version 4.0.5 - for PostgreSQL 17.4
     * version 4.0.3 - for PostgreSQL 17.2  
-    * version 4.0.4 - for PostgreSQL 13.18, 14.15, 15.10, 16.6 
+    * version 4.0.4 - for PostgreSQL 13.20, 14.17, 15.12, 16.8 
+

--- a/docs/images.md
+++ b/docs/images.md
@@ -7,21 +7,25 @@ Percona Operator for PostgreSQL version {{ release }}:
 |:---------------------------------------------------------------------|:-----------------------------------------------------------------|
 | percona/percona-postgresql-operator:2.6.0 (x86_64)                   | fb1b6b08e986a21b30ce5e538c54e92e5fd978cd62abf17856c74582a237e931 |
 | percona/percona-postgresql-operator:2.6.0 (ARM64)                    | 4e545bebaa66e43c1c0707bb576b4047ca5dd6fc0f4fb326b553cba744b337ae |
+|percona/percona-postgresql-operator:2.6.0-ppg17.4-postgres           | 142ea1573c67fdb60a197352c576a1d01da247eee3b3fc0f09e86dd4c916cc82 |
 | percona/percona-postgresql-operator:2.6.0-ppg17.2-postgres           | acb876c29ddcb8ca3d157a83e2b0e8410dabbd0c4c35257fa8f66a9f0b981fda |
 | percona/percona-postgresql-operator:2.6.0-ppg16.8-postgres           | 7ecc5320ae341778140dd90e1e628ab3552f12cd4fb07e93070b034dc9e6c776 |
 | percona/percona-postgresql-operator:2.6.0-ppg15.12-postgres          | db6d09dcb2e6f4c3a10de521fe0b008df0675741ee062fdbcaabfd4a466200d1 |
 | percona/percona-postgresql-operator:2.6.0-ppg14.17-postgres          | 31dd06dd76df480da58638c1ae14cbff762b1057701ccc20af9bc86c264b4962 |
 | percona/percona-postgresql-operator:2.6.0-ppg13.20-postgres          | 95f25de125cd43e825dea64be943e097459cfda09550877fbf460626913a2e9d |
+| percona/percona-postgresql-operator:2.6.0-ppg17.4-postgres-gis3.3.8  | 836884826761a858d183616acff5c069fbad3a47e9014146a6acdfe2d40f6962 |
 | percona/percona-postgresql-operator:2.6.0-ppg17.2-postgres-gis3.3.7  | 8bd0c645431cfebd1b365c05ba2e5748d81d00dbf5b76cf2f3f3a411ef1cb14e |
 | percona/percona-postgresql-operator:2.6.0-ppg16.8-postgres-gis3.3.8  | 4787f0b40b25d14dc4e724dc97f76a3fe13b97a372437fe803cc2208dbcf102c |
 | percona/percona-postgresql-operator:2.6.0-ppg15.12-postgres-gis3.3.8 | fed24afbf62ee384fe5cfdd1b8646ba7e5579aa500e9fc84be5467d66ca6d46b |
 | percona/percona-postgresql-operator:2.6.0-ppg14.17-postgres-gis3.3.8 | e243d07702754adaee2cb789d03bc3a2ca142d9c7d93bfe871cb7b47323e8bdf |
 | percona/percona-postgresql-operator:2.6.0-ppg13.20-postgres-gis3.3.8 | bb1095f5cd462e7d381fefe39ee1e12c9a1d11ba5a249d0aca065b1e5243efb7 |
+| percona/percona-postgresql-operator:2.6.0-ppg17.4-pgbouncer1.24.0    | 01199912786772df11994ff7f4231a117bfc856a5c8fc3fb55e6d2f33c6d4230 |
 | percona/percona-postgresql-operator:2.6.0-ppg17.2-pgbouncer1.23.1    | a51586295a2abc228470c0d73087a0de646cd7b58d0c6796c08719ad7635d89f |
 | percona/percona-postgresql-operator:2.6.0-ppg16.8-pgbouncer1.24.0    | fbf8c89259d821df04b007f3e750d3f3ed902a9dd366bb0efe72ba3683974b99 |
 | percona/percona-postgresql-operator:2.6.0-ppg15.12-pgbouncer1.24.0   | 9ef6204ebf626ee85d2a2afd405ee44ebb5e252bb1ac07ebaed44fa658bfb5f0 |
 | percona/percona-postgresql-operator:2.6.0-ppg14.17-pgbouncer1.24.0   | 6ffc19f626b738b096635a0b1a2e4fbb28f800723759c58bd8491e9857b2fc19 |
 | percona/percona-postgresql-operator:2.6.0-ppg13.20-pgbouncer1.24.0   | a1c25e9834fbc8ad58477fc47ef868ccf3c696bd488114efc8c7f61c66961356 |
+| percona/percona-postgresql-operator:2.6.0-ppg17.4-pgbackrest2.54.2   | 6b4648e00f0cd187ef7d20542d8df93f0a4d2f79df3946343e57bce40ee119aa |
 | percona/percona-postgresql-operator:2.6.0-ppg17.2-pgbackrest2.54.0   | a3641d58a49fe4f771f3638c9fa18c71dd2f9aba1054e5693d3756134676cb3e |
 | percona/percona-postgresql-operator:2.6.0-ppg16.8-pgbackrest2.54.2   | eca4f0153fd75c87bb35e54e5358da458a502bcc7671a798ddf60f6a87246ba8 |
 | percona/percona-postgresql-operator:2.6.0-ppg15.12-pgbackrest2.54.2	 | 9d33160904b7862d03c1018e4bf80247ea175918b7b0b4d4907e175045ddf4d1 |

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -6,7 +6,7 @@ Cluster components:
 
 | Operator | [PostgreSQL :octicons-link-external-16:](https://www.postgresql.org/) | [pgBackRest :octicons-link-external-16:](https://pgbackrest.org/) | [pgBouncer :octicons-link-external-16:](http://pgbouncer.github.io/) |
 |:---------|:--------|:-----|:-------|
-| [2.6.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md) | 13 - 17 | 2.54.2 for PostgreSQL 13-16, 2.54.0 for PostgreSQL 17 | 1.24.0 for PostgreSQL 13-16, 1.23.1 for PostgreSQL 17 |
+| [2.6.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md) | 13 - 17 | 2.54.2 for PostgreSQL 13-16 and 17.4, <br> 2.54.0 for PostgreSQL 17.2  | 1.24.0 for PostgreSQL 13-16 and 17.2, <br> 1.23.1 for PostgreSQL 17 |
 | [2.5.1](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.5.1.md) | 12 - 16 | 2.54.2 | 1.24.0 |
 | [2.5.0](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.5.0.md) | 12 - 16 | 2.53-1 | 1.23.1 |
 | [2.4.1](ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.4.1.md) | 12 - 16 | 2.51   | 1.22.1 |

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -203,6 +203,7 @@ nav:
             - "Backup encryption": backup-encryption.md
             - "Speed up backups": async-archiving.md
             - "Backup retention": backup-retention.md
+            - backups-delete.md
           - "High availability and scaling": scaling.md
           - "Add sidecar containers": sidecar.md
           - "Restart or pause the cluster": pause.md

--- a/variables.yml
+++ b/variables.yml
@@ -3,16 +3,15 @@
 release: 2.6.0
 pmm2recommended: 2.44.0
 commandName: 'kubectl'
-postgresrecommended: 17.2
-postgres16recommended: 16.6
+postgresrecommended: 17.4
+postgres16recommended: 16.8
 certmanagerrecommended: '1.17.0'
 pgbouncerrecommended: '1.24.0'
-pgbouncer17recommended: '1.23.1'
+pgbouncer17_2recommended: '1.23.1'
 pgbackrestrecommended: '2.54.2'
-pgbackrest17recommended: '2.54.0'
+pgbackrest17_2recommended: '2.54.0'
 gkerecommended: '1.31'
 postgisrecommended: 3.3.8
-postgis17recommended: 3.3.7
 k8s_monitor_tag: 'v0.1.1'
 
 


### PR DESCRIPTION
updated release notes,
updated image hashes
updated components versions for PG 17.4

modified:   docs/ReleaseNotes/Kubernetes-Operator-for-PostgreSQL-RN2.6.0.md
	modified:   docs/assets/fragments/sw-versions.txt
	modified:   docs/images.md
	modified:   docs/versions.md
	modified:   mkdocs-base.yml
	modified:   variables.yml