### PR TITLE
Fix version update-operator.md and removed space

### DIFF
--- a/docs/update-operator.md
+++ b/docs/update-operator.md
@@ -34,9 +34,7 @@ Upgrading Percona Operator for PostgreSQL and its associated Custom Resource Def
     `minor.major` version by more than one, you need to make several
     incremental upgrades sequentially. 
     
-    For example, to upgrade the CRD and Operator from the version 2.4.
-    0 to 2.6.0, first upgrade it from 2.4.0 to 2.5.1, and then from 2.
-    5.1 to 2.6.0.
+    For example, to upgrade the CRD and Operator from the version 2.4.0 to 2.6.0, first upgrade it from 2.4.0 to 2.5.1, and then from 2.5.1 to 2.6.0.
 
 2. CRD supports **the last 3 minor versions of the Operator**. This means it is compatible with the newest Operator version and the two previous minor versions. If the Operator is older than the CRD by no more than two versions, you should be able to continue using the old Operator version. But updating the CRD and Operator is the recommended path.
 


### PR DESCRIPTION
There was a space between major and minor version.

This is how it currently renders, because of the /n which leads to two versions having a space

<img width="1429" height="129" alt="image" src="https://github.com/user-attachments/assets/c7300f58-3270-461b-b936-7249da732107" />

